### PR TITLE
Fix `fem` and `b-tree` link

### DIFF
--- a/lessons/09-query-performance/C-create-an-index.md
+++ b/lessons/09-query-performance/C-create-an-index.md
@@ -28,3 +28,5 @@ B-trees are compact, fairly simple data structures that are suited to general in
 [This page from the docs about index types][indexes] is helpful to glance at.
 
 [indexes]: https://www.postgresql.org/docs/current/indexes-types.html
+[fem]: https://frontendmasters.com/courses/computer-science-v2/
+[btree]: https://en.wikipedia.org/wiki/B-tree


### PR DESCRIPTION
Added `fem` link to `computer-science-v2` course on frontend masters and `btree` link to Wikipedia's page for b-tree